### PR TITLE
waratek_security sourceType selectable in Splunk Enterprise 6.2.2

### DIFF
--- a/local/props.conf
+++ b/local/props.conf
@@ -1,2 +1,4 @@
 [waratek_security]
+pulldown_type = true 
+
 EXTRACT-waratek_security = \S+\s+\S+\s+(?<log_level>\S+)\s+(?<rule_action>\S+)\s+(?<jvc_name>\S+)\s+(?<rule_category>\w+):(?<rule_subcategory>\w*)\s+\[(?<rule_parameter>.*?)\] - \[(?<rule_data>.*?)\](\s+\[(?<request_metadata>\{.*\}?)\])?


### PR DESCRIPTION
Splunk 6.2.2 required the props.conf file to be modified for custom source-types to show up on the interface.